### PR TITLE
deprecated individual ssl option parameters and added new ssl_opts parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
 install:
   - "pip install -e ."
   - "pip install pytest"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ changes may be introduced.
 - Currently only JSON-RPC is supported.  We plan to add support for XML-RPC also.
 - The connection pooling system should be considered alpha-quality.  We would love feedback, but don't expect
   a bug-free experience.
-- We plan to support Python 3.x (no testing has been done, but using 2to3 may work with little modification)
 
 ## Installation
 
@@ -57,16 +56,13 @@ for connection pooling.
 ```python
 from rpctools.jsonrpc import ServerProxy, Fault
 
-proxy = ServerProxy(uri='https://example.com/jsonrpc',
-                    ca_certs='/path/to/ca-bundle.crt', # PEM-encoded contatenated set of CA certificates
-                    validate_cert_hostname=True # (This is also the default.)
-                    )
-
+proxy = ServerProxy('https://example.com/jsonrpc', ssl_opts={
+    'ca_certs': '/path/to/ca-bundle.crt', # PEM-encoded contatenated set of CA certificates
+})
 try:
     proxy.someServerMethod(param1, param2)
 except Fault:
-    # Fault instances are used to communicate server-side exceptions.
-    raise
+    raise  # Fault instances are used to communicate server-side exceptions.
 ```
 
 ### ... with basic auth
@@ -76,15 +72,11 @@ The underlying httplib library supports providing basic auth in the URI:
 ```python
 from rpctools.jsonrpc import ServerProxy, Fault
 
-proxy = ServerProxy(uri='https://foo:pass@example.com/jsonrpc',
-                    ca_certs='/path/to/ca-bundle.crt'
-                    )
-
+proxy = ServerProxy('https://foo:pass@example.com/jsonrpc')
 try:
     proxy.requiresAuth(param1, param2)
 except Fault:
-    # Fault instances are used to communicate server-side exceptions.
-    raise
+    raise  # Fault instances are used to communicate server-side exceptions.
 ```
 
 ### ... or client certs
@@ -92,17 +84,15 @@ except Fault:
 ```python
 from rpctools.jsonrpc import ServerProxy, Fault
 
-proxy = ServerProxy(uri='https://example.com/jsonrpc',
-                    key_file='/path/to/client.key', # PEM-encoded
-                    cert_file='/path/to/client.crt', # PEM-encoded
-                    ca_certs='/path/to/ca-bundle.crt'
-                    )
-
+proxy = ServerProxy('https://example.com/jsonrpc', ssl_opts={
+    keyfile='/path/to/client.key',   # PEM-encoded
+    certfile='/path/to/client.crt',  # PEM-encoded
+    ca_certs='/path/to/ca-bundle.crt'
+})
 try:
     proxy.someServerMethod(param1, param2)
 except Fault:
-    # Fault instances are used to communicate server-side exceptions.
-    raise
+    raise  # Fault instances are used to communicate server-side exceptions.
 ```
 
 ### ... connection pooling (ALPHA!)
@@ -113,13 +103,10 @@ to use the connection pool feature.
 ```python
 from rpctools.jsonrpc import ServerProxy, Fault
 
-proxy = ServerProxy(uri='http://example.com/jsonrpc',
-                    pool_connections=True)
-
+proxy = ServerProxy('http://example.com/jsonrpc', pool_connections=True)
 for (param1, param2) in some_params_list:
-	try:
-	    proxy.someServerMethod(param1, param2)
-	except Fault:
-	    # Fault instances are used to communicate server-side exceptions.
-	    raise
+    try:
+        proxy.someServerMethod(param1, param2)
+    except Fault:
+        raise  # Fault instances are used to communicate server-side exceptions.
 ```

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1,8 +1,0 @@
-News: jsonrpcclient
-===================
-
-.. contents::
-
-0.1.0
------
-* Initial alpha-quality release.

--- a/rpctools/__init__.py
+++ b/rpctools/__init__.py
@@ -1,7 +1,7 @@
 __license__ = """Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
- 
+
   http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software

--- a/rpctools/jsonrpc/__init__.py
+++ b/rpctools/jsonrpc/__init__.py
@@ -4,7 +4,7 @@ from rpctools.jsonrpc.exc import Fault, ProtocolError
 __license__ = """Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
- 
+
   http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software

--- a/rpctools/jsonrpc/exc.py
+++ b/rpctools/jsonrpc/exc.py
@@ -23,12 +23,14 @@ class JsonRpcError(Exception):
     with the server, whereas faults are problems reported back from the remote server.
     """
 
+
 class ConnectionError(JsonRpcError):
     """
     Indicates an error at the TCP connection level.
 
     This exception is raised when a socket.error is raised from the underlying httplib layer.
     """
+
 
 class ProtocolError(JsonRpcError):
     """
@@ -42,11 +44,13 @@ class ProtocolError(JsonRpcError):
         self.errcode = errcode
         self.errmsg = errmsg
         self.headers = headers
+
     def __repr__(self):
         return (
             "<ProtocolError for %s: %s %s>" %
             (self.url, self.errcode, self.errmsg)
             )
+
 
 class ResponseError(JsonRpcError):
     """
@@ -56,6 +60,7 @@ class ResponseError(JsonRpcError):
     exception will be raised if the response does not match this structure.
     """
     pass
+
 
 class Fault(Exception):
     """

--- a/rpctools/jsonrpc/pool.py
+++ b/rpctools/jsonrpc/pool.py
@@ -16,6 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
+
 class Pool(ThreadLocal):
     """
     A thread-local subclass that is responsible for managing a pool of connections,
@@ -28,6 +29,7 @@ class Pool(ThreadLocal):
         self.connections = {}
 
 pool = Pool()
+
 
 class TLSConnectionPoolMixin(object):
     """
@@ -58,7 +60,7 @@ class TLSConnectionPoolMixin(object):
         Overrides method to return an existing connection from thread-local pool
         instead of creating a new one.
         """
-        if not host in pool.connections:
+        if host not in pool.connections:
             self.logger.debug("No connection in pool for %s, creating." % host)
             conn = super(TLSConnectionPoolMixin, self).connect(host)
             pool.connections[host] = conn

--- a/rpctools/jsonrpc/transport.py
+++ b/rpctools/jsonrpc/transport.py
@@ -22,6 +22,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
+
 class Transport(object):
     """
     Handles an HTTP transaction to a JSON-RPC server.
@@ -78,7 +79,7 @@ class Transport(object):
 
         # Add headers
         headers['User-Agent'] = self.user_agent
-        if not 'content-type' in header_keys_lower:
+        if 'content-type' not in header_keys_lower:
             headers['Content-Type'] = 'application/json'
         headers['Content-Length'] = len(body) if body is not None else 0
 
@@ -127,19 +128,16 @@ class SafeTransport(Transport):
     Extends/overrides Transport to use HTTPS connections.
     """
 
-    def __init__(self, key_file=None, cert_file=None, ca_certs=None, validate_cert_hostname=True, timeout=None):
+    def __init__(self, validate_cert_hostname=True, timeout=None, ssl_opts=None):
         super(SafeTransport, self).__init__(timeout=timeout)
-        self.key_file = key_file
-        self.cert_file = cert_file
-        self.ca_certs = ca_certs
         self.validate_cert_hostname = validate_cert_hostname
+        self.ssl_opts = ssl_opts or {}
 
     def connect(self, host):
         """
         Connect securely (HTTPS) to host.
         """
-        return ssl_wrapper.CertValidatingHTTPSConnection(host, key_file=self.key_file, cert_file=self.cert_file,
-                   ca_certs=self.ca_certs, validate_cert_hostname=self.validate_cert_hostname)
+        return ssl_wrapper.CertValidatingHTTPSConnection(host, ssl_opts=self.ssl_opts, validate_cert_hostname=self.validate_cert_hostname)
 
 
 class TLSConnectionPoolTransport(TLSConnectionPoolMixin, Transport):

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,8 @@ zip_ok = False
 
 [egg_info]
 ;tag_build = dev
+
+[pep8]
+max-line-length=999
+ignore=E121,E123,E126,E226,E24,E704,E221,E127,E128,W503,E731,E131,E711,E712
+exclude=six.py

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except ImportError:
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-version = '0.2.1'
+version = '0.3.0'
 
 news = os.path.join(os.path.dirname(__file__), 'docs', 'news.rst')
 news = open(news).read()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -61,7 +61,7 @@ class TestUrllibImplementation(object):
 
     @pytest.mark.parametrize('uri,host', [
         ('http://myusername:mypassword@myhostname.com/foo/bar/baz.html',
-         'myhostname.com'),
+         'myhostname.com:80'),
     ])
     def test_host(self, uri, host):
         proxy = ServerProxy(uri)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34
+envlist = py27,py33,py34,py35
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
I made a few other minor adjustments while I was in here:
- added Python 3.5 to the list of versions tested by tox/travis
- added PEP8 rules to ``setup.cfg`` and made some styling fixes
- removed ``news.rst`` which hadn't ever been updated and probably doesn't need to exist until version 1.0 anyway
- bumped the version number