### PR TITLE
Enable Server Name Indication by default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except ImportError:
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-version = '0.3.1'
+version = '0.3.2'
 
 long_description = """
 The rpctools package provides client libraries for working with RPC services


### PR DESCRIPTION
This is required when hosting multiple servers on the same IP, but with different hostnames.